### PR TITLE
fix:mediaplayer暂停/重启时对i2s进行stop/begin操作,避免暂停期间输出杂音.

### DIFF
--- a/src/MediaPlayer.cpp
+++ b/src/MediaPlayer.cpp
@@ -107,6 +107,7 @@ bool MediaPlayer::pause()
 {
   if(state == PLAYING){
     //Only meaningful in playing state
+    output->stop();
     state = PAUSED;
     return true;
   }
@@ -117,6 +118,7 @@ bool MediaPlayer::resume()
 {
   if(state == PAUSED){
     //Resume play when paused
+    output->begin();
     state = PLAYING;
     return true;
   }


### PR DESCRIPTION
暂停/重启时进行stop/begin操作, 避免暂停期间输出杂音.